### PR TITLE
fix(extra fzf): shell escaping

### DIFF
--- a/lua/tokyonight/extra/fzf.lua
+++ b/lua/tokyonight/extra/fzf.lua
@@ -70,7 +70,7 @@ export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS \
   --info=inline-right \
   --ansi \
   --layout=reverse \
-  --border=none
+  --border=none \
 %s
 "
 ]]


### PR DESCRIPTION
## Description
The generated shell code is missing a backslash before the color code setup

https://github.com/alezkv/tokyonight.nvim/blob/main/extras/fzf/tokyonight_night.sh#L6

```
  --layout=reverse \
  --border=none          <-- here
  --color=bg+:#283457 \
```

This can lead to incorrect variable evaluation if the code is consumed by the Antidote Zsh plugin manager in the following manner:

```
folke/tokyonight.nvim path:extras/fzf/tokyonight_night.sh
```
